### PR TITLE
Allow binding a specified incoming address on Mac OSX.

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -1191,6 +1191,10 @@ int ws_add_tcp(ws_server_t *serv, in_addr_t ip, int port) {
     addr.sin_family = AF_INET;
     addr.sin_addr.s_addr = ip;
     addr.sin_port = htons(port);
+#ifdef __APPLE__
+    addr.sin_len = sizeof(struct sockaddr_in);
+    memset(&addr.sin_zero, 0, sizeof(addr.sin_zero));
+#endif
     int fd = socket(PF_INET, SOCK_STREAM, 0);
     if(fd < 0) return -1;
     int size = 1;


### PR DESCRIPTION
On OSX sockaddr_in needs to have sin_len set and sin_zero should be zeroed out, otherwise we cannot bind specific incoming addresses (only INADDR_ANY would work).

Note: the #ifdef **APPLE** might not be needed, I expect that setting sin_len and sin_zero should work fine on Linux (although is not required), but I haven't tested it.
